### PR TITLE
Optimized conversions

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 crond
 php-fpm
-python /var/python_app/main.py
+python /var/python_app/main.py bypass_convert
 /usr/sbin/httpd -D FOREGROUND


### PR DESCRIPTION
This optimizes the conversion process.

I added a flag argument "bypass_convert" which tells main.py not to convert the library.

Added this flag to startup.sh

This way, when startup.sh is ran when the container spawns, it focuses on building out the library and getting the webserver up, that way we can focus on the conversions while the webserver is already online.