### PR TITLE
Client based format selection

### DIFF
--- a/www/library.php
+++ b/www/library.php
@@ -150,6 +150,7 @@
         public $upload_date;
         public $pretty_date;
         public $asmr_file;
+        public $asmr_formats = array();
         public $asmr_runtime;
         public $comment_count;
         public $description;
@@ -185,8 +186,25 @@
             } elseif (is_file($path . '/asmr.m4a')) {
                 $this->asmr_file = $path . "/asmr.m4a";
             } else {
-                $this->asmr_file = $path . "/asmr.webm"; # unsupported but here to cover non-converted files.
+                $this->asmr_file = $path . "/asmr.webm";
             }
+            # Gather formats so we can selectively choose.
+            if (is_file($path . '/asmr.mp3')) {
+                array_push($this->asmr_formats, ($path . "/asmr.mp3"));
+            }
+            if (is_file($path . '/asmr.flac')) {
+                array_push($this->asmr_formats, ($path . "/asmr.flac"));
+            }
+            if (is_file($path . '/asmr.opus')) {
+                array_push($this->asmr_formats, ($path . "/asmr.opus"));
+            }
+            if (is_file($path . '/asmr.m4a')) {
+                array_push($this->asmr_formats, ($path . "/asmr.m4a"));
+            } 
+            if (is_file($path . '/asmr.webm')) {
+                array_push($this->asmr_formats, ($path . "/asmr.webm"));
+            }
+
             $this->asmr_runtime = file_get_contents($path . "/runtime.txt");
         }
         # Used to display this video as a row in channel_index

--- a/www/player.php
+++ b/www/player.php
@@ -145,9 +145,11 @@ $me = new Video(".")
         <p class="description"><?php echo $me->description;?></p>
         <div class="controls">
             <audio id="asmr" controls autoplay onplay="play_update()" onpause="pause_update()">
-                <source src="<?php echo $me->asmr_file; ?>" type="audio/mpeg">
-                <source src="<?php echo $me->asmr_file; ?>" type="audio/ogg">
-                <source src="<?php echo $me->asmr_file; ?>" type="audio/wav">
+                <?php
+                    foreach(array_reverse($me->asmr_formats) as &$value) {
+                        echo "<source src=\"" . $value . "\">";
+                    }
+                ?>
                 <p>Your browser does not support the audio tag.</p>
             </audio>
             <div class="button" onclick="skipBack(60)">


### PR DESCRIPTION
Allows client to select it's format.

most formats are supported on android so having this allows android users to experience their ASMR bliss before the conversion happens. For people on ios (like me) we'll have the option to play mp3 once it's been converted.

This is a win-win as it adds compatibility without removing options for others. 