### PR TITLE
Join convert processes

### DIFF
--- a/python_app/main.py
+++ b/python_app/main.py
@@ -49,6 +49,8 @@ def convert_library(asmr_directory, threads=4):
                     p = Process(target=convert, args=(dir_path, "asmr." + format, convert_to))
                     p.start()
                     processes.append(p)
+    for p in processes:
+        p.join()
 
 def get_my_folder():
     return os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
I was failing to properly join the processes after running conversions. This breaks mp3 conversions sometimes. The parent process would quit killing the child processes.

I will need to do another full re-conversion of prod to fix any missed errors. I estimate under 10 entries would be affected by this, but I still want to ensure they're fixed. 

I spent about 30 minutes trying to code up a way to analyze the mp3 files to look for files that have issues but ultimately was unsuccessful.