### PR TITLE
Update web

### DIFF
--- a/python_app/update_web.py
+++ b/python_app/update_web.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+from syslog import LOG_ODELAY
+from main import Channel, load_channels
+import filecmp
+
+print("Updating web files in library...")
+
+# Update player.php files
+count = 0
+for root, dirs, files in os.walk("/var/ASMRchive"):
+    for file in files:
+        if file == "player.php":
+            path = os.path.join(root, file)
+            if not filecmp.cmp(path, "/var/www/html/player.php"): # only update if there are changes
+                count += 1
+                os.remove(path)
+                shutil.copy("/var/www/html/player.php", path)
+
+print("Updated " + str(count) + " out-of-date player.php files.")
+
+count = 0
+# Check for old naming convention and update channel index
+channels = load_channels("/var/ASMRchive")
+for chan in channels:
+    path = os.path.join(chan.path, "index.php")
+    if os.path.exists(path):
+        count += 1
+        shutil.move(path, os.path.join(root, "channel.php"))
+print("Renamed " + str(count) + " channel index files with old naming convention.")
+
+count = 0
+# Update channel.php files
+for root, dirs, files in os.walk("/var/ASMRchive"):
+    for file in files:
+        if file == "channel.php":
+            path = os.path.join(root, file)
+            if not filecmp.cmp(path, "/var/www/html/channel_index.php"): # only update if there are changes
+                count += 1
+                os.remove(path)
+                shutil.copy("/var/www/html/channel_index.php", path)
+print("Updated " + str(count) + " out-of-date channel.php files.")
+

--- a/python_app/update_web.py
+++ b/python_app/update_web.py
@@ -26,7 +26,7 @@ for chan in channels:
     path = os.path.join(chan.path, "index.php")
     if os.path.exists(path):
         count += 1
-        shutil.move(path, os.path.join(root, "channel.php"))
+        shutil.move(path, os.path.join(chan.path, "channel.php"))
 print("Renamed " + str(count) + " channel index files with old naming convention.")
 
 count = 0

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,5 @@
 crond
 php-fpm
+python /var/python_app/update_web.py
 python /var/python_app/main.py bypass_convert
 /usr/sbin/httpd -D FOREGROUND

--- a/www/library.php
+++ b/www/library.php
@@ -98,7 +98,7 @@
             $this->alias = $alias;
             $this->dir_name = $dir_name;
             $this->path = "ASMR/" . $dir_name . "/";
-            $this->link = $this->path . "index.php";
+            $this->link = $this->path . "channel.php";
             $temp = scandir($this->path);
             $count = 0;
             foreach ($temp as $vid) {
@@ -136,7 +136,7 @@
             if ($this->count == 0) {
                 echo '<tr style="cursor: not-allowed;"';
             } else {
-                echo '<tr onclick="window.location=' . "'" . $this->path . "index.php'" . '"';
+                echo '<tr onclick="window.location=' . "'" . $this->path . "channel.php'" . '"';
             }
             echo '><td><img class="pfp" src=' . $this->path . 'pfp.png></td>
             <td class="channel">' . $this->alias . '</td>


### PR DESCRIPTION
Adds feature requested in #26 

On container startup, makes sure the library has updated web files. This process used to be done on the host manually during updates. This is now automated and runs every time the container starts.

Note I also updated channel/index.php to channel/channel.php (just a rename). This update is executed automatically by update_web.py. This makes it easier to perform bulk actions on the file (using like find | grep channel.php and what not). 