### PR TITLE
Revert "Upgraded to Fedora 38 on base image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:33
 
 # Install rpmfusion for ffmpeg
 RUN dnf install -y https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm


### PR DESCRIPTION
Reverts whgDosumi/ASMRchive#64

I didn't read the logs well enough, we need to add PIP explicitly now, the tested version was still on fedora 33 upon checking. Reverting for testing.