### PR TITLE
Fix r-proxy comments

### DIFF
--- a/www/player.php
+++ b/www/player.php
@@ -203,7 +203,7 @@ $me = new Video(".")
         ?>
         <div id="comment_form">
             <h4 style="padding: 0;margin:0;">New Comment:</h4>
-            <form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]); ?>" method="post" id="comment_form">
+            <form method="post" id="comment_form">
                 Name:<br> <input id="name_box" type="text" name="user_name" maxlength="40" required><input type="submit" value="Post" id="post_button"><br>
                 Message: <br><textarea id="message_box" type="text" name="text" required></textarea>
                 <p onclick="append_timestamp()" id="comment_timestamp">Current time: 00:00</p>


### PR DESCRIPTION
Fixes issue where comments were not working behind a reverse proxy. 

This was fixed by removing the explicit action for the post request on the comment form. I encountered this on other forms in admintools as well, and fixed it the same way. It turns out not specifying the action assumes to post the current web page, which eliminates the complexity of the url being different behind a reverse proxy.