### PR TITLE
feat: Remove unnecessary tables

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -37,7 +37,7 @@
         <a href="./index.php">
             <img src="./images/ASMRchive.png" alt="logo" class="top_logo">
         </a>
-        <table>
+        <table <?php if(count($chans) <= 0) { echo "hidden"; } ?> >
             <thead>
                 <th colspan="2">Channel</th>
                 <th>Status</th>
@@ -53,11 +53,11 @@
                         array_push($zeros, $chan);
                     }
                 }
-                ?>
-                <th colspan="4" class="splitter">No Entries &#128546;</th>
-                <?php
-                foreach ($zeros as $chan) {
-                    $chan->display_row();
+                if (count($zeros) > 0) {
+                    echo "<th colspan=\"4\" class=\"splitter\">No Entries &#128546;</th>";
+                    foreach ($zeros as $chan) {
+                        $chan->display_row();
+                    }
                 }
                 ?>
             </tbody>


### PR DESCRIPTION
This change removes unused tables in ASMRchive's index. Now ASMRchive will conditionally show the table headers only if the table contains content.

See issue #80 to see how this behaved previously.

Here's a screenshot of my dev build running this branch:
![image](https://github.com/whgDosumi/ASMRchive/assets/60369937/57775c87-6091-4861-87c3-514f571b1f45)

Now, when I remove the entry with 0 ASMR, you'll see that the "No Entries" table header is now gone:
![image](https://github.com/whgDosumi/ASMRchive/assets/60369937/2179e5d8-f59b-499e-a26a-bb3a8f753a94)

And now, when there are 0 channels at all nothing shows:
![image](https://github.com/whgDosumi/ASMRchive/assets/60369937/b45e6a0b-d79f-42b1-a1f5-2b6146b231f2)

Final test case, when there are only channels that have no content: 
![image](https://github.com/whgDosumi/ASMRchive/assets/60369937/e9ebcdad-6afc-477b-8eff-bcb48dd9c987)

This is much cleaner looking than before, and removes unnecessary tables for content that doesn't exist.