### PR TITLE
101 ios timestamp issue

### DIFF
--- a/www/library.php
+++ b/www/library.php
@@ -6,7 +6,7 @@
     # These are the supported audio formats
     # Check with Dominic before updating these, to ensure the conversion will work.
     # The order is the order of preference the client will use if all are present.
-    $SUPPORTED_FORMATS = array(".wav", ".webm", ".flac", ".m4a", ".opus", ".mp3");
+    $SUPPORTED_FORMATS = array(".wav", ".webm", ".flac", ".opus", ".m4a", ".mp3");
 
     header("Cache-Control: no-cache, no-store, must-revalidate"); // HTTP 1.1.
     header("Pragma: no-cache"); // HTTP 1.0.

--- a/www/player.php
+++ b/www/player.php
@@ -300,11 +300,23 @@ $me = new Video(".")
             http.send();
             return http.status != 404;
         }
-        if (!url_exists("asmr.mp3")) {
+        if (!url_exists("asmr.m4a")) {
             if (iOS()) {
                 alert("Conversion not complete, if this doesn't work wait 15 minutes and try again.")
             }
         }
+        // Remove webm option from ios devices:
+        document.addEventListener("DOMContentLoaded", function() {
+            if (iOS()) {
+                var sources = audio.getElementsByTagName("source");
+                for (var i = 0; i < sources.length; i++) {
+                    if (sources[i].src.endsWith(".webm")) {
+                        audio.removeChild(sources[i]);
+                    }
+                }
+                audio.load();
+            }
+        });
         var audio = document.getElementById("asmr");
         audio.currentTime = <?php echo $start_timestamp; ?>;
         button = document.getElementById("play");
@@ -369,10 +381,9 @@ $me = new Video(".")
         }
 
         function set_time(seconds) {
+            audio.pause();
             audio.currentTime = seconds;
-            if (audio.paused) {
-                play_pause();
-            }
+            audio.play();
         }
 
         function seconds_to_hms(seconds) {


### PR DESCRIPTION
Move to AAC m4a audio for IOS. Dropping webm support for ios devices.

This should fix #101

In the production library, I'm going to remove all of the mp3 copies we have, and re-convert everything to aac with the updated convert function in main.py.