### PR TITLE
feat: Add version to admintools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ COPY python_app /var/python_app
 # Make force_scan.sh executable
 RUN chmod 770 /var/python_app/force_scan.sh
 
+# Copy in version for webserver.
+ADD version.txt /var/www/html/version.txt
+
 # Expose httpd.
 EXPOSE 80
 

--- a/www/admintools.css
+++ b/www/admintools.css
@@ -116,6 +116,19 @@ tbody {
     border-bottom-right-radius: 15px;
 }
 
+#version {
+    padding: 2px;
+    margin: 0;
+    font-size: 20px;
+    font-weight: bold;
+    color: black;
+    background-color: darkseagreen;
+    position: fixed;
+    top: 0;
+    right: 0;
+    border-bottom-left-radius: 5px;
+}
+
 #post_button {
     float: right;
     width: 25%;

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -11,7 +11,11 @@
 <body>
     <?php
     include "/var/www/html/library.php";
-    
+    // Get current version
+    $asmrchive_version = "Unknown Version";
+    if (file_exists("version.txt")) {
+        $asmrchive_version = file_get_contents("version.txt");
+    }
     $channel_folders = scandir("ASMR/");
     $channels = array();
     
@@ -202,6 +206,9 @@
     ?>
     <a href="index.php">
         <div id="backbutton"><img id="backimage" src="images/back.png"></div>
+    </a>
+    <a href="https://github.com/whgDosumi/ASMRchive">
+        <p id="version"><?php echo $asmrchive_version; ?></p>
     </a>
     <div id="main">
         <a href="index.php">


### PR DESCRIPTION
Adds the current version to the top right of admintools. Can be moved in the future if I want to put something else there. Clicking the version brings you to the github page.

<img width="82" alt="image" src="https://github.com/user-attachments/assets/c8267436-ed0e-4778-90da-5e76acdcadb3">
