### PR TITLE
Yt dlp version check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN dnf update -y && dnf -y install \
 RUN python -m pip install --upgrade pip
 
 # Set up crontab to run the python app every 15 minutes.
-RUN (echo -e "*/15 * * * * /usr/bin/python /var/python_app/main.py >> \"/var/ASMRchive/.appdata/logs/python/main-\$(date +\%Y-\%m-\%d)-asmr.log\" 2>&1\n* * * * * /var/python_app/force_scan.sh") | crontab -
+RUN (echo -e "*/15 * * * * /usr/bin/python3 /var/python_app/main.py >> \"/var/ASMRchive/.appdata/logs/python/main-\$(date +\%Y-\%m-\%d)-asmr.log\" 2>&1\n* * * * * /var/python_app/flag_check.sh\n0 * * * * /usr/bin/python3 /var/python_app/check_dlp.py") | crontab -
 
 # install python requirements
 COPY python_app/requirements.txt /var/python_requirements.txt
@@ -46,7 +46,7 @@ ADD www /var/www/html
 COPY python_app /var/python_app
 
 # Make force_scan.sh executable
-RUN chmod 770 /var/python_app/force_scan.sh
+RUN chmod 770 /var/python_app/flag_check.sh
 
 # Copy in version for webserver.
 ADD version.txt /var/www/html/version.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ pipeline {
                 """
                 echo "Starting Container"
                 sh "podman container start jenkins-asmrchive"
-                sh "podman run --network=\"host\" asmrchive-test 'http://localhost/Jenkins_ASMRchive/'"
+                sh "podman run --network=\"host\" asmrchive-test --url http://localhost/Jenkins_ASMRchive/"
             }
         }
         stage ("Integration Test (DLP Updates)") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ pipeline {
                 podman create \
                     -p 4445:80 \
                     --name jenkins-asmrchive \
+                    -e DLP_VER=2024.12.06 \
                     jenkins-asmrchive
                 """
                 echo "Starting Container"
@@ -85,6 +86,7 @@ pipeline {
                 podman create \
                     -p 4445:80 \
                     --name jenkins-asmrchive \
+                    -e DLP_VER=2024.12.06 \
                     jenkins-asmrchive
                 """
                 echo "Starting Container"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         booleanParam(defaultValue: true, description: "Skip manual review?", name: "SKIP_REVIEW")
         booleanParam(defaultValue: false, description: "Use Image Cache?", name: "USE_CACHE")
         booleanParam(defaultValue: false, description: "Suppress Telegram Notifications", name: "SUPPRESS_NOTIFS")
+        booleanParam(defaultValue: false, description: "Pause Between Steps", name: "Pause")
         text(name: "Build ID", defaultValue: "", description: "Build ID")
     }
     stages {
@@ -34,8 +35,6 @@ pipeline {
         stage ("Tidy Up") { // Cleans up environment to ensure we don't have artifacts from old builds
             steps {
                 script {
-                    // We'll call the image created by this pipeline jenkins-asmrchive
-                    // Containers will be called the same
                     echo "Removing existing testing containers"
                     sh "podman ps -a -q -f ancestor=jenkins-asmrchive | xargs -I {} podman container rm -f {} || true" // Removes all containers that exist under the image
                     if (!params.USE_CACHE) {
@@ -110,7 +109,6 @@ pipeline {
                 sh "podman run \
                         --network=\"host\" \
                         asmrchive-test \
-                        --url http://localhost/Jenkins_ASMRchive/ \
                         --test dlponly"
             }
         }

--- a/python_app/check_dlp.py
+++ b/python_app/check_dlp.py
@@ -1,0 +1,32 @@
+import subprocess
+import re
+import json
+
+
+# Returns a dict with bool up_to_date and the two version strings.
+def check_version():
+    p = subprocess.run(["/usr/local/bin/yt-dlp", "-U"], capture_output = True, text = True)
+    stdout = p.stdout.splitlines()
+    if "yt-dlp is up to date" in p.stdout:
+        up_to_date = True
+        match = re.search(r"stable@\d{4}\.\d{2}\.\d{2}", stdout[0])
+        current_version = match.group()
+        latest_version = current_version
+    else:
+        up_to_date = False
+        current_version = re.search(r"stable@\d{4}\.\d{2}\.\d{2}", stdout[0]).group()
+        latest_version = re.search(r"stable@\d{4}\.\d{2}\.\d{2}", stdout[1]).group()
+    stdout = p.stdout.splitlines()
+    output = {}
+    output["up_to_date"] = up_to_date
+    output["current_version"] = current_version
+    output["latest_version"] = latest_version
+    return output
+    
+
+
+
+if __name__ == "__main__":
+    result = check_version()
+    with open("/var/ASMRchive/.appdata/yt_dlp_info.json", "w") as f:
+        json.dump(result, f)

--- a/python_app/flag_check.sh
+++ b/python_app/flag_check.sh
@@ -7,6 +7,11 @@ check() {
         rm -f /var/ASMRchive/.appdata/flags/scan_flag.txt
         python /var/python_app/main.py >> "/var/ASMRchive/.appdata/logs/python/main-$(date +\%Y-\%m-\%d)-asmr.log" 2>&1
     fi
+    if [ -f "/var/ASMRchive/.appdata/flags/update_dlp_flag.txt" ]; then
+        rm -f "/var/ASMRchive/.appdata/flags/update_dlp_flag.txt"
+        python3 -m pip install -U "yt-dlp[default]"
+        python /var/python_app/check_dlp.py
+    fi
 }
 
 check

--- a/python_app/flag_check.sh
+++ b/python_app/flag_check.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 # Runs twice, because this is being ran every 1m by crontab and I wanted to run it every 30s
-for i in {1..12}; do
-    if [ -f "/var/www/html/flags/scan_flag.txt" ]; then
-        rm -f /var/www/html/flags/scan_flag.txt
+
+check() {
+    if [ -f "/var/ASMRchive/.appdata/flags/scan_flag.txt" ]; then
+        rm -f /var/ASMRchive/.appdata/flags/scan_flag.txt
         python /var/python_app/main.py >> "/var/ASMRchive/.appdata/logs/python/main-$(date +\%Y-\%m-\%d)-asmr.log" 2>&1
     fi
-    sleep 5
-done
+}
+
+check
+sleep 30
+check

--- a/python_app/flag_check.sh
+++ b/python_app/flag_check.sh
@@ -12,6 +12,10 @@ check() {
         python3 -m pip install -U "yt-dlp[default]"
         python /var/python_app/check_dlp.py
     fi
+    if [ -f "/var/ASMRchive/.appdata/flags/check_dlp_flag.txt" ]; then
+        rm -f "/var/ASMRchive/.appdata/flags/check_dlp_flag.txt"
+        python /var/python_app/check_dlp.py
+    fi
 }
 
 check

--- a/python_app/unupdate.sh
+++ b/python_app/unupdate.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-python -m pip uninstall -y yt-dlp
-python -m pip install -U yt-dlp==2024.12.06

--- a/python_app/unupdate.sh
+++ b/python_app/unupdate.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python -m pip uninstall -y yt-dlp
+python -m pip install -U yt-dlp==2024.12.06

--- a/startup.sh
+++ b/startup.sh
@@ -49,6 +49,7 @@ chmod o+w /var/ASMRchive/.appdata/channels
 chown apache /var/ASMRchive/.appdata/channels/*
 chgrp apache /var/ASMRchive/.appdata/channels/*
 
+python /var/python_app/check_dlp.py
 python /var/python_app/clear_downloads.py
 python /var/python_app/update_web.py
 python /var/python_app/main.py bypass_convert >> \"/var/ASMRchive/.appdata/logs/python/main-`date +\%Y-\%m-\%d`-asmr.log\" 2>&1

--- a/startup.sh
+++ b/startup.sh
@@ -21,10 +21,10 @@ then
 fi
 
 # Make a directory for the scan flag
-if [ ! -d "/var/www/html/flags" ]
+if [ ! -d "/var/ASMRchive/.appdata/flags" ]
 then
-    mkdir "/var/www/html/flags"
-    chown apache /var/www/html/flags
+    mkdir "/var/ASMRchive/.appdata/flags"
+    chown apache /var/ASMRchive/.appdata/flags
 fi
 
 # Create relevant log locations in case we're updating from an older version of ASMRchive

--- a/startup.sh
+++ b/startup.sh
@@ -3,6 +3,14 @@
 crond
 php-fpm
 
+# Override for yt-dlp version
+if [ -z "${DLP_VER+x}" ]; then
+    echo "DLP-VER not overridden."
+else
+    python -m pip uninstall -y yt-dlp
+    python -m pip install -U yt-dlp==$DLP_VER
+fi
+
 if [ ! -d "/var/ASMRchive/.appdata" ] # If appdata doesn't already exist, initialize it
 then
     mkdir "/var/ASMRchive/.appdata"

--- a/testing/test.py
+++ b/testing/test.py
@@ -148,7 +148,7 @@ print(f"Testing on: {homepage_url}")
 #Initialize chrome webdriver
 web = webdriver.Chrome(options=chrome_options)
 # Get our main pages, ensure we can connect properly
-timeout = 60
+timeout = 120
 web.get(homepage_url)
 WebDriverWait(web, timeout).until(
     EC.presence_of_element_located((By.ID, "main"))

--- a/testing/test.py
+++ b/testing/test.py
@@ -148,6 +148,7 @@ print(f"Testing on: {homepage_url}")
 #Initialize chrome webdriver
 web = webdriver.Chrome(options=chrome_options)
 # Get our main pages, ensure we can connect properly
+print("Waiting for website to be up...")
 timeout = 120
 rr = 5
 t = 0
@@ -168,16 +169,20 @@ web.get(admintools_url)
 WebDriverWait(web, timeout).until(
     EC.presence_of_element_located((By.ID, "main"))
 )
+print("Sites up!")
 
 # Do the DLP test if requested.
 if args.test.lower() == "dlp" or args.test.lower() == "dlponly":
+    print("Performing DLP Test...")
     web.get(admintools_url)
     # Verify the version is wrong
     assert "stable@2024.12.06" in web.page_source
+    print("Current version is stable@2024.12.06, not up to date.")
     # Click the update button
     web.find_element(By.ID, "dlp_update").click()
     alert = WebDriverWait(web, 10).until(EC.alert_is_present())
     alert.accept()
+    print("Update button pressed, waiting for update to complete.")
     # Wait for the version to update
     max_retries = 15
     refresh_rate = 5
@@ -194,10 +199,12 @@ if args.test.lower() == "dlp" or args.test.lower() == "dlponly":
             web.get(admintools_url)
             web.find_element(By.ID, "dlp_update")
         except:
+            print("Update button is gone! YT-DLP is up to date!")
             passed = True
             break
     assert passed
     if args.test.lower() == "dlponly":
+        print("dlponly specified, exiting.")
         exit()
 
 # Add test channel

--- a/testing/test.py
+++ b/testing/test.py
@@ -129,8 +129,9 @@ else:
 
 p = argparse.ArgumentParser()
 p.add_argument("--url")
-p.add_argument("--test")
+p.add_argument("--test", default="")
 args = p.parse_args()
+
 
 if args.url:
     # Allow passing a different url for when it's not running on the same host (or to test a reverse proxy)

--- a/testing/test.py
+++ b/testing/test.py
@@ -149,6 +149,14 @@ print(f"Testing on: {homepage_url}")
 web = webdriver.Chrome(options=chrome_options)
 # Get our main pages, ensure we can connect properly
 timeout = 120
+rr = 5
+t = 0
+while t < timeout:
+    r = requests.get(homepage_url)
+    if r.status_code == 200:
+        break
+    t += rr
+    time.sleep(rr)
 web.get(homepage_url)
 WebDriverWait(web, timeout).until(
     EC.presence_of_element_located((By.ID, "main"))

--- a/testing/test.py
+++ b/testing/test.py
@@ -178,7 +178,9 @@ if args.test.lower() == "dlp" or args.test.lower() == "dlponly":
         except:
             passed = True
             break
-assert passed
+    assert passed
+    if args.test.lower() == "dlponly":
+        exit()
 
 # Add test channel
 web.get(admintools_url)

--- a/testing/test.py
+++ b/testing/test.py
@@ -148,8 +148,15 @@ print(f"Testing on: {homepage_url}")
 #Initialize chrome webdriver
 web = webdriver.Chrome(options=chrome_options)
 # Get our main pages, ensure we can connect properly
+timeout = 60
 web.get(homepage_url)
+WebDriverWait(web, timeout).until(
+    EC.presence_of_element_located((By.ID, "main"))
+)
 web.get(admintools_url)
+WebDriverWait(web, timeout).until(
+    EC.presence_of_element_located((By.ID, "main"))
+)
 
 # Do the DLP test if requested.
 if args.test.lower() == "dlp" or args.test.lower() == "dlponly":

--- a/testing/test.py
+++ b/testing/test.py
@@ -152,9 +152,12 @@ timeout = 120
 rr = 5
 t = 0
 while t < timeout:
-    r = requests.get(homepage_url)
-    if r.status_code == 200:
-        break
+    try:
+        r = requests.get(homepage_url)
+        if r.status_code == 200:
+            break
+    except:
+        pass
     t += rr
     time.sleep(rr)
 web.get(homepage_url)

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -228,6 +228,11 @@
             <table>
                     <?php
                         $dlp_info = get_dlp_update();
+                        // Ensure necessary values are set, otherwise set to defaults
+                        $dlp_info["current_version"] = $dlp_info["current_version"] ?? "Unknown";
+                        $dlp_info["latest_version"] = $dlp_info["latest_version"] ?? "Unknown";
+                        // Default to true because we don't want the button to show. 
+                        $dlp_info["up_to_date"] = $dlp_info["up_to_date"] ?? true;
                     ?>
                 <thead>
                     <th colspan="2">YT-DLP Version</th>

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -383,7 +383,7 @@
             </table>
         </form>
         <form method="post" enctype="multipart/form-data">
-            <input type="submit" name="force-scan" value="Scan Now" id="force-scan">
+            <input type="submit" name="force-scan" value="ASMR Scan Now" id="force-scan">
         </form>
         <br>
         <table>

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -97,10 +97,15 @@
         }
 
         // Update yt-dlp
-        if (isset($_POST['dlp_update'])) {
+        if (isset($_POST["dlp_update"])) {
             // Flag for yt-dlp to be updated
             touch("/var/ASMRchive/.appdata/flags/update_dlp_flag.txt");
             echo "<script type='text/javascript'>alert('Container will update yt-dlp. Reload in a few minutes to verify the update was completed.');</script>";
+        }
+        // Check yt-dlp
+        if (isset($_POST["dlp_check"])) {
+            touch("/var/ASMRchive/.appdata/flags/check_dlp_flag.txt");
+            echo "<script type='text/javascript'>alert('Will refresh yt-dlp info, please wait a moment and refresh to see the update.');</script>";
         }
 
         // Upload ASMR
@@ -246,12 +251,14 @@
                         <td class="upload_table_cell"> Latest: </td>
                         <td class="upload_table_cell"> <?php echo $dlp_info["latest_version"]; ?> </td>
                     </tr>
+                    <tr>
+                    <td class="upload_table_cell\"><input type="submit" name="dlp_check" value="Check" id="dlp_check" class="submit_button"> </td>
                     <?php
                         if (!$dlp_info["up_to_date"]) {
-                            echo "<tr><td></td>
-                            <td class=\"upload_table_cell\"><input type=\"submit\" name=\"dlp_update\" value=\"Update\" id=\"dlp_update\" class=\"submit_button\"> </td> </tr>";
+                            echo "<td class=\"upload_table_cell\"><input type=\"submit\" name=\"dlp_update\" value=\"Update\" id=\"dlp_update\" class=\"submit_button\"> </td>";
                         }
                     ?>
+                    </tr>
                 </tbody>
             </table>
         </form>

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -45,7 +45,7 @@
         // force scan
         if (isset($_POST['force-scan'])) {
             touch("/var/ASMRchive/.appdata/flags/scan_flag.txt");
-            echo "<script type='text/javascript'>alert('Forcing ASMR Scan in Next 30 Seconds.');</script>"; 
+            echo "<script type='text/javascript'>alert('Forcing ASMR Scan.');</script>"; 
         }
         // Request Video
 

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -228,40 +228,6 @@
         <a href="index.php">
             <img src="images/ASMRchive.png" alt="logo" class="top_logo">
         </a>
-
-        <form method="post" enctype="multipart/form-data">
-            <table>
-                    <?php
-                        $dlp_info = get_dlp_update();
-                        // Ensure necessary values are set, otherwise set to defaults
-                        $dlp_info["current_version"] = $dlp_info["current_version"] ?? "Unknown";
-                        $dlp_info["latest_version"] = $dlp_info["latest_version"] ?? "Unknown";
-                        // Default to true because we don't want the button to show. 
-                        $dlp_info["up_to_date"] = $dlp_info["up_to_date"] ?? true;
-                    ?>
-                <thead>
-                    <th colspan="2">YT-DLP Version</th>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td class="upload_table_cell"> Current: </td>
-                        <td class="upload_table_cell"> <?php echo $dlp_info["current_version"]; ?> </td>
-                    </tr>
-                    <tr>
-                        <td class="upload_table_cell"> Latest: </td>
-                        <td class="upload_table_cell"> <?php echo $dlp_info["latest_version"]; ?> </td>
-                    </tr>
-                    <tr>
-                    <td class="upload_table_cell\"><input type="submit" name="dlp_check" value="Check" id="dlp_check" class="submit_button"> </td>
-                    <?php
-                        if (!$dlp_info["up_to_date"]) {
-                            echo "<td class=\"upload_table_cell\"><input type=\"submit\" name=\"dlp_update\" value=\"Update\" id=\"dlp_update\" class=\"submit_button\"> </td>";
-                        }
-                    ?>
-                    </tr>
-                </tbody>
-            </table>
-        </form>
         <form method="post" enctype="multipart/form-data">
             <table>
                 <thead>
@@ -379,6 +345,39 @@
                         </td>
                         <td class="upload_table_cell"><input class="submit_button" type="submit" name="send" value="Send" id="request_video_button">
                         </td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
+        <form method="post" enctype="multipart/form-data">
+            <table>
+                    <?php
+                        $dlp_info = get_dlp_update();
+                        // Ensure necessary values are set, otherwise set to defaults
+                        $dlp_info["current_version"] = $dlp_info["current_version"] ?? "Unknown";
+                        $dlp_info["latest_version"] = $dlp_info["latest_version"] ?? "Unknown";
+                        // Default to true because we don't want the button to show. 
+                        $dlp_info["up_to_date"] = $dlp_info["up_to_date"] ?? true;
+                    ?>
+                <thead>
+                    <th colspan="2">YT-DLP Version</th>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="upload_table_cell"> Current: </td>
+                        <td class="upload_table_cell"> <?php echo $dlp_info["current_version"]; ?> </td>
+                    </tr>
+                    <tr>
+                        <td class="upload_table_cell"> Latest: </td>
+                        <td class="upload_table_cell"> <?php echo $dlp_info["latest_version"]; ?> </td>
+                    </tr>
+                    <tr>
+                    <td class="upload_table_cell\"><input type="submit" name="dlp_check" value="Check" id="dlp_check" class="submit_button"> </td>
+                    <?php
+                        if (!$dlp_info["up_to_date"]) {
+                            echo "<td class=\"upload_table_cell\"><input type=\"submit\" name=\"dlp_update\" value=\"Update\" id=\"dlp_update\" class=\"submit_button\"> </td>";
+                        }
+                    ?>
                     </tr>
                 </tbody>
             </table>

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -45,7 +45,7 @@
         // force scan
         if (isset($_POST['force-scan'])) {
             touch("/var/ASMRchive/.appdata/flags/scan_flag.txt");
-            echo "<script type='text/javascript'>alert('Forcing ASMR Scan.');</script>"; 
+            echo "<script type='text/javascript'>alert('Forcing ASMR Scan in Next 30 Seconds.');</script>"; 
         }
         // Request Video
 
@@ -94,6 +94,13 @@
                     echo "<script type='text/javascript'>alert('Verify the channel name is between 1 and 24 characters.');</script>";
                 }
             }
+        }
+
+        // Update yt-dlp
+        if (isset($_POST['dlp_update'])) {
+            // Flag for yt-dlp to be updated
+            touch("/var/ASMRchive/.appdata/flags/update_dlp_flag.txt");
+            echo "<script type='text/javascript'>alert('Container will update yt-dlp. Reload in a few minutes to verify the update was completed.');</script>";
         }
 
         // Upload ASMR
@@ -217,7 +224,32 @@
             <img src="images/ASMRchive.png" alt="logo" class="top_logo">
         </a>
 
-        
+        <form method="post" enctype="multipart/form-data">
+            <table>
+                    <?php
+                        $dlp_info = get_dlp_update();
+                    ?>
+                <thead>
+                    <th colspan="2">YT-DLP Version</th>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="upload_table_cell"> Current: </td>
+                        <td class="upload_table_cell"> <?php echo $dlp_info["current_version"]; ?> </td>
+                    </tr>
+                    <tr>
+                        <td class="upload_table_cell"> Latest: </td>
+                        <td class="upload_table_cell"> <?php echo $dlp_info["latest_version"]; ?> </td>
+                    </tr>
+                    <?php
+                        if (!$dlp_info["up_to_date"]) {
+                            echo "<tr><td></td>
+                            <td class=\"upload_table_cell\"><input type=\"submit\" name=\"dlp_update\" value=\"Update\" id=\"dlp_update\" class=\"submit_button\"> </td> </tr>";
+                        }
+                    ?>
+                </tbody>
+            </table>
+        </form>
         <form method="post" enctype="multipart/form-data">
             <table>
                 <thead>
@@ -340,7 +372,7 @@
             </table>
         </form>
         <form method="post" enctype="multipart/form-data">
-            <input type="submit" name="force-scan" value="Force Scan" id="force-scan">
+            <input type="submit" name="force-scan" value="Scan Now" id="force-scan">
         </form>
         <br>
         <table>

--- a/www/admintools.php
+++ b/www/admintools.php
@@ -44,7 +44,7 @@
 
         // force scan
         if (isset($_POST['force-scan'])) {
-            touch("/var/www/html/flags/scan_flag.txt");
+            touch("/var/ASMRchive/.appdata/flags/scan_flag.txt");
             echo "<script type='text/javascript'>alert('Forcing ASMR Scan.');</script>"; 
         }
         // Request Video

--- a/www/library.php
+++ b/www/library.php
@@ -53,6 +53,10 @@
         return $text;
     }
 
+    function get_dlp_update() {
+        return json_decode(file_get_contents('/var/ASMRchive/.appdata/yt_dlp_info.json'), true);
+    }
+
     #Generates a random string of length $length (defaults 20)
     function generateRandomString($length = 20) {
         $characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';


### PR DESCRIPTION
Adds a feature that allows us to update yt-dlp live inside the container without rebuilding, right from the webui. I've also updated the bot to notify me if the version is out of date, so I can stay on top of it. Wrote a new step in the pipeline to ensure the feature works during testing. 

![image](https://github.com/user-attachments/assets/22635c15-e090-4797-94d4-8c1f2a0c3a1b)
