### PR TITLE
fix: Adds deno to path. Required for yt-dlp to use it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 RUN curl -fsSL https://deno.land/install.sh > deno_install.sh
 RUN sh deno_install.sh -y
 RUN rm deno_install.sh
+# Add to path
+RUN ln -s /root/.deno/bin/deno /usr/local/bin/deno
 
 # Write build date
 RUN python3 -c "from datetime import datetime; print(datetime.today().strftime('%Y-%m-%d'))" >> /var/www/html/version.txt


### PR DESCRIPTION
Simple fix adds deno to path so yt-dlp can use it. This didn't come up as an issue during testing, somehow the image I had on my dev machine must have had deno on path while testing. Adding it manually here fixes the issue.