### PR TITLE
feat: Cookie upload via admintools

### DIFF
--- a/php.ini
+++ b/php.ini
@@ -920,7 +920,7 @@ cli_server.color = On
 [Date]
 ; Defines the default timezone used by the date functions
 ; http://php.net/date.timezone
-;date.timezone =
+date.timezone = America/New_York
 
 ; http://php.net/date.default-latitude
 ;date.default_latitude = 31.7667

--- a/python_app/flag_check.sh
+++ b/python_app/flag_check.sh
@@ -16,6 +16,25 @@ check() {
         rm -f "/var/ASMRchive/.appdata/flags/check_dlp_flag.txt"
         python /var/python_app/check_dlp.py
     fi
+
+    # Clean up expired cookie files
+    # Filenames look like: cookie-20260215-0457-a3f2.txt
+    # The expiry timestamp is the 2nd and 3rd sections (YYYYMMDD-HHMM)
+    cookie_dir="/var/ASMRchive/.appdata/cookies"
+    now=$(date +%Y%m%d-%H%M)
+
+    for cookie_file in "$cookie_dir"/cookie-*.txt; do
+        if [ ! -f "$cookie_file" ]; then
+            continue
+        fi
+
+        filename=$(basename "$cookie_file")
+        expiry=$(echo "$filename" | cut -d'-' -f2-3)
+
+        if [ "$now" \> "$expiry" ] || [ "$now" = "$expiry" ]; then
+            rm -f "$cookie_file"
+        fi
+    done
 }
 
 check

--- a/startup.sh
+++ b/startup.sh
@@ -50,7 +50,8 @@ ln -s /var/ASMRchive/.appdata/channels /var/www/html/channels # Give webserver a
 fi
 
 # Set desired file permissions
-chmod o-r /var/ASMRchive/.appdata/cookies 
+chgrp apache /var/ASMRchive/.appdata/cookies
+chmod 730 /var/ASMRchive/.appdata/cookies
 chmod o-r /var/ASMRchive/.appdata/logs 
 chmod o+w /var/ASMRchive/.appdata/channels
 # Give apache ownership of the channel files

--- a/www/admintools.css
+++ b/www/admintools.css
@@ -254,6 +254,21 @@ tbody {
     bottom: 10px;
 }
 
+#cookie_content {
+    font-size: 16px;
+    width: 375px;
+    min-height: 120px;
+    display: inline-block;
+    margin-left: 0px;
+}
+
+#cookie_ttl {
+    font-size: 30px;
+    margin-left: 0px;
+    position: relative;
+    bottom: 6px;
+}
+
 #force-scan {
     height: 100%;
     font-size: 30px;


### PR DESCRIPTION
Adds a form to admintools that accepts Netscape-format cookies with a configurable TTL (15/30/60/120 min). Cookies are saved with expiration timestamps in the filename and automatically cleaned up by flag_check.sh.

- Cookie files are write-only (0200) to prevent Apache from reading them
- Cookies directory permissions updated so Apache can write but not list
- Fixed PHP timezone (was UTC, now matches container EST)